### PR TITLE
Don't append line numbers to file names

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ var chromeProfileToCallgrind = function(profile, outStream) {
             continue;
         }
         var call = calls[callUID];
-        outStream.write(_s.sprintf('fl=%s:%d\n', call.url, call.lineNumber));
+        outStream.write(_s.sprintf('fl=%s\n', call.url));
         outStream.write(_s.sprintf('fn=%s\n', fnForCall(call)));
         outStream.write(_s.sprintf('%d %d %d\n', call.lineNumber,
                 call.selfTime, call.selfHitCount));
@@ -103,8 +103,8 @@ var chromeProfileToCallgrind = function(profile, outStream) {
                 continue;
             }
             var childCall = call.childCalls[childCallUID];
-            outStream.write(_s.sprintf('cfi=%s:%d\n',
-                    childCall.url, childCall.lineNumber));
+            outStream.write(_s.sprintf('cfi=%s\n',
+                    childCall.url));
             outStream.write(_s.sprintf('cfn=%s\n', fnForCall(childCall)));
 
             outStream.write(_s.sprintf('calls=0 %d\n', childCall.lineNumber));


### PR DESCRIPTION
This lets kcachegrind properly group profiling results by file. It also avoids
the weird duplicate display of line numbers (as in 'Foo.js:123:123'). The line
numbers are still displayed as expected in the content pane, and the call
graph is unaffected.
