### PR TITLE
Efficiency Improvements

### DIFF
--- a/bin/chrome2calltree.js
+++ b/bin/chrome2calltree.js
@@ -30,10 +30,6 @@ parser.addArgument(['-k', '--kcachegrind'], {
             "remove it after kcachegrind exits.",
     'action': 'storeTrue'
 });
-parser.addArgument(['-m', '--mutate'], {
-    'help': "Allow the script to mutate the input, as an optimization.",
-    'action': 'storeTrue'
-});
 
 var args = parser.parseArgs();
 
@@ -92,7 +88,7 @@ var launchKCacheGrind = function(logpath) {
 };
 
 readEntireStream(inStream, function(contents) {
-    var copy = args.mutate ? false : true;
+    var copy = false; // default to not mutate for efficiency
     chrome2calltree.chromeProfileToCallgrind(JSON.parse(contents), outStream, copy);
     outStream.on('finish', function() {
         if (outStream !== process.stdout) {

--- a/bin/chrome2calltree.js
+++ b/bin/chrome2calltree.js
@@ -30,6 +30,10 @@ parser.addArgument(['-k', '--kcachegrind'], {
             "remove it after kcachegrind exits.",
     'action': 'storeTrue'
 });
+parser.addArgument(['-m', '--mutate'], {
+    'help': "Allow the script to mutate the input, as an optimization.",
+    'action': 'storeTrue'
+});
 
 var args = parser.parseArgs();
 
@@ -88,7 +92,8 @@ var launchKCacheGrind = function(logpath) {
 };
 
 readEntireStream(inStream, function(contents) {
-    chrome2calltree.chromeProfileToCallgrind(JSON.parse(contents), outStream);
+    var copy = args.mutate ? false : true;
+    chrome2calltree.chromeProfileToCallgrind(JSON.parse(contents), outStream, copy);
     outStream.on('finish', function() {
         if (outStream !== process.stdout) {
           outStream.close();

--- a/bin/chrome2calltree.js
+++ b/bin/chrome2calltree.js
@@ -88,7 +88,7 @@ var launchKCacheGrind = function(logpath) {
 };
 
 readEntireStream(inStream, function(contents) {
-    var copy = false; // default to not mutate for efficiency
+    var copy = false; // For efficiency, we mutate the profile in place
     chrome2calltree.chromeProfileToCallgrind(JSON.parse(contents), outStream, copy);
     outStream.on('finish', function() {
         if (outStream !== process.stdout) {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ var walkTree = function(node, cb) {
 };
 
 var chromeProfileToCallgrind = function(profile, outStream) {
-    var timedProfile = _.cloneDeep(profile);
+    var timedProfile = profile; //_.cloneDeep(profile);
     calculateTimes(timedProfile);
 
     var calls = {};

--- a/index.js
+++ b/index.js
@@ -58,6 +58,9 @@ var fnForCall = function(call) {
 };
 
 var chromeProfileToCallgrind = function(profile, outStream, copy) {
+    if (typeof copy === 'undefined') {
+	copy = true;
+    }
     var timedProfile = copy ? _.cloneDeep(profile) : profile;
 
     calculateTimes(timedProfile);

--- a/index.js
+++ b/index.js
@@ -45,11 +45,11 @@ var treeToArrayAcc = function(node, acc) {
         }
     }
     return acc;
-}
+};
 
 var treeToArray = function(node) {
     return treeToArrayAcc(node, []);
-}
+};
 
 var fnForCall = function(call) {
     var baseUrl = _.last(_.first(call.url.split("?")).split("/"));
@@ -65,10 +65,13 @@ var chromeProfileToCallgrind = function(profile, outStream, copy) {
     var calls = {};
 
     var allNodes = treeToArray(timedProfile.head);
-    for (var i = 0; i < allNodes.length; i++) {
+
+    // declare iterator vars used in two different blocks
+    var i, j, call, childCall; 
+    for (i = 0; i < allNodes.length; i++) {
         var node = allNodes[i];
 
-        var call = calls[node.callUID] = calls[node.callUID] || {
+        call = calls[node.callUID] = calls[node.callUID] || {
             functionName: node.functionName,
             url: node.url,
             selfTime: 0,
@@ -81,11 +84,11 @@ var chromeProfileToCallgrind = function(profile, outStream, copy) {
 
         var childCalls = call.childCalls;
         if (node.children) {
-            for(var j = 0; j < node.children.length; j++) {
+            for(j = 0; j < node.children.length; j++) {
                 var child = node.children[j];
 
                 var childUID = child.callUID;
-                var childCall = childCalls[childUID] = childCalls[childUID] || {
+                childCall = childCalls[childUID] = childCalls[childUID] || {
                     functionName: child.functionName,
                     url: child.url,
                     totalHitCount: 0,
@@ -106,8 +109,8 @@ var chromeProfileToCallgrind = function(profile, outStream, copy) {
     // by using Object.keys, we can skip the
     // hasOwnProperty check
     var callUIDArray = Object.keys(calls);
-    for (var i = 0; i < callUIDArray.length; i++) {
-        var call = calls[callUIDArray[i]];
+    for (i = 0; i < callUIDArray.length; i++) {
+        call = calls[callUIDArray[i]];
 
         outStream.write(_s.sprintf('fl=%s\n', call.url));
         outStream.write(_s.sprintf('fn=%s\n', fnForCall(call)));
@@ -115,8 +118,8 @@ var chromeProfileToCallgrind = function(profile, outStream, copy) {
                 call.selfTime, call.selfHitCount));
 
         var childCallUIDArray = Object.keys(call.childCalls);
-        for (var j = 0; j < childCallUIDArray.length; j++) {
-            var childCall = call.childCalls[childCallUIDArray[j]];
+        for (j = 0; j < childCallUIDArray.length; j++) {
+            childCall = call.childCalls[childCallUIDArray[j]];
 
             outStream.write(_s.sprintf('cfi=%s\n', childCall.url));
             outStream.write(_s.sprintf('cfn=%s\n', fnForCall(childCall)));

--- a/index.js
+++ b/index.js
@@ -57,13 +57,14 @@ var fnForCall = function(call) {
             call.functionName, baseUrl, call.lineNumber);
 };
 
-var chromeProfileToCallgrind = function(profile, outStream) {
+var chromeProfileToCallgrind = function(profile, outStream, copy) {
+    var timedProfile = copy ? _.cloneDeep(profile) : profile;
 
-    calculateTimes(profile);
+    calculateTimes(timedProfile);
 
     var calls = {};
 
-    var allNodes = treeToArray(profile.head);
+    var allNodes = treeToArray(timedProfile.head);
     for (var i = 0; i < allNodes.length; i++) {
         var node = allNodes[i];
 
@@ -99,7 +100,7 @@ var chromeProfileToCallgrind = function(profile, outStream) {
 
     outStream.write('events: ms hits\n');
     outStream.write(_s.sprintf('summary: %d %d\n',
-            profile.totalTime, profile.totalHitCount));
+            timedProfile.totalTime, timedProfile.totalHitCount));
 
 
     // by using Object.keys, we can skip the

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var _s = require("underscore.string");
 
 // Based on WebInspector.CPUProfileView in CPUProfileView.js in Blink source.
 // https://github.com/yoavweiss/Blink/blob/master/Source/devtools/front_end/CPUProfileView.js
-var totalHitCount = function(node) {
+var totalHitCount = function (node) {
     var result = node.hitCount;
     for (var i = 0; i < node.children.length; i++) {
         result += totalHitCount(node.children[i]);
@@ -13,45 +13,54 @@ var totalHitCount = function(node) {
     return result;
 };
 
-var calculateTimes = function(profile) {    
+var calculateTimesForNode = function (node, samplingInterval) {
+    node.selfTime = node.hitCount * samplingInterval;
+    node.selfHitCount = node.hitCount;
+    var totalHitCount = node.hitCount;
+    for (var i = 0; i < node.children.length; i++) {
+        totalHitCount += calculateTimesForNode(node.children[i], samplingInterval);
+    }
+    node.totalTime = totalHitCount * samplingInterval;
+    node.totalHitCount = totalHitCount;
+    return totalHitCount;
+};
+
+var calculateTimes = function (profile) {    
     profile.totalHitCount = totalHitCount(profile.head);
     profile.totalTime = 1000 * (profile.endTime - profile.startTime);
-
     var samplingInterval = profile.totalTime / profile.totalHitCount;
 
-    var calculateTimesForNode = function(node) {
-        node.selfTime = node.hitCount * samplingInterval;
-        node.selfHitCount = node.hitCount;
-        var totalHitCount = node.hitCount;
-        for (var i = 0; i < node.children.length; i++) {
-            totalHitCount += calculateTimesForNode(node.children[i]);
-        }
-        node.totalTime = totalHitCount * samplingInterval;
-        node.totalHitCount = totalHitCount;
-        return totalHitCount;
-    };
-    calculateTimesForNode(profile.head);
+    calculateTimesForNode(profile.head, samplingInterval);
 };
 
-var walkTree = function(node, cb) {
-    if (!node) {
-        return;
+var treeToArrayAcc = function (node, acc) {
+    acc.push(node);
+    for (var i = 0; i < node.children.length; i++) {
+        acc = acc.concat(treeToArrayAcc(node.children[i], []));
     }
-    cb(node);
-    if (!node.children) {
-        return;
-    }
-    node.children.forEach(function(child) {
-        walkTree(child, cb);
-    });
+    return acc;
+}
+
+var treeToArray = function (node) {
+    return treeToArrayAcc(node, []);
+}
+
+var fnForCall = function(call) {
+    var baseUrl = _.last(_.first(call.url.split("?")).split("/"));
+    return _s.sprintf("%s %s:%d",
+            call.functionName, baseUrl, call.lineNumber);
 };
 
-var chromeProfileToCallgrind = function(profile, outStream) {
-    var timedProfile = profile; //_.cloneDeep(profile);
-    calculateTimes(timedProfile);
+var chromeProfileToCallgrind = function (profile, outStream) {
+
+    calculateTimes(profile);
 
     var calls = {};
-    walkTree(timedProfile.head, function(node) {
+
+    var allNodes = treeToArray(profile.head);
+    for (var i = 0; i < allNodes.length; i++) {
+        var node = allNodes[i];
+
         var call = calls[node.callUID] = calls[node.callUID] || {
             functionName: node.functionName,
             url: node.url,
@@ -64,46 +73,42 @@ var chromeProfileToCallgrind = function(profile, outStream) {
         call.selfTime += node.selfTime;
 
         var childCalls = call.childCalls;
-        if (node.children) {
-            node.children.forEach(function(child) {
-                var childUID = child.callUID;
-                var childCall = childCalls[childUID] = childCalls[childUID] || {
-                    functionName: child.functionName,
-                    url: child.url,
-                    totalHitCount: 0,
-                    totalTime: 0,
-                    lineNumber: child.lineNumber
-                };
-                childCall.totalHitCount += child.totalHitCount;
-                childCall.totalTime += child.totalTime;
-            });
+        for(var j = 0; j < node.children.length; j++) {
+            var child = node.children[j];
+
+            var childUID = child.callUID;
+            var childCall = childCalls[childUID] = childCalls[childUID] || {
+                functionName: child.functionName,
+                url: child.url,
+                totalHitCount: 0,
+                totalTime: 0,
+                lineNumber: child.lineNumber
+            };
+            childCall.totalHitCount += child.totalHitCount;
+            childCall.totalTime += child.totalTime;
         }
-    });
+    }
 
     outStream.write('events: ms hits\n');
     outStream.write(_s.sprintf('summary: %d %d\n',
-            timedProfile.totalTime, timedProfile.totalHitCount));
+            profile.totalTime, profile.totalHitCount));
 
-    var fnForCall = function(call) {
-        var baseUrl = _.last(_.first(call.url.split("?")).split("/"));
-        return _s.sprintf("%s %s:%d",
-                call.functionName, baseUrl, call.lineNumber);
-    };
 
-    for (var callUID in calls) {
-        if (!calls.hasOwnProperty(callUID)) {
-            continue;
-        }
-        var call = calls[callUID];
+    // by using Object.keys, we can skip the
+    // hasOwnProperty check
+    var callUIDArray = Object.keys(calls);
+    for (var i = 0; i < callUIDArray.length; i++) {
+        var call = calls[callUIDArray[i]];
+
         outStream.write(_s.sprintf('fl=%s\n', call.url));
         outStream.write(_s.sprintf('fn=%s\n', fnForCall(call)));
         outStream.write(_s.sprintf('%d %d %d\n', call.lineNumber,
                 call.selfTime, call.selfHitCount));
-        for (var childCallUID in call.childCalls) {
-            if (!call.childCalls.hasOwnProperty(childCallUID)) {
-                continue;
-            }
-            var childCall = call.childCalls[childCallUID];
+
+        var childCallUIDArray = Object.keys(call.childCalls);
+        for (var j = 0; j < childCallUIDArray.length; j++) {
+            var childCall = call.childCalls[childCallUIDArray[j]];
+
             outStream.write(_s.sprintf('cfi=%s\n', childCall.url));
             outStream.write(_s.sprintf('cfn=%s\n', fnForCall(childCall)));
 

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ var _s = require("underscore.string");
 
 // Based on WebInspector.CPUProfileView in CPUProfileView.js in Blink source.
 // https://github.com/yoavweiss/Blink/blob/master/Source/devtools/front_end/CPUProfileView.js
-var totalHitCount = function (node) {
+var totalHitCount = function(node) {
     var result = node.hitCount;
     for (var i = 0; i < node.children.length; i++) {
         result += totalHitCount(node.children[i]);
@@ -13,7 +13,7 @@ var totalHitCount = function (node) {
     return result;
 };
 
-var calculateTimesForNode = function (node, samplingInterval) {
+var calculateTimesForNode = function(node, samplingInterval) {
     node.selfTime = node.hitCount * samplingInterval;
     node.selfHitCount = node.hitCount;
     var totalHitCount = node.hitCount;
@@ -25,7 +25,7 @@ var calculateTimesForNode = function (node, samplingInterval) {
     return totalHitCount;
 };
 
-var calculateTimes = function (profile) {    
+var calculateTimes = function(profile) {    
     profile.totalHitCount = totalHitCount(profile.head);
     profile.totalTime = 1000 * (profile.endTime - profile.startTime);
     var samplingInterval = profile.totalTime / profile.totalHitCount;
@@ -33,7 +33,7 @@ var calculateTimes = function (profile) {
     calculateTimesForNode(profile.head, samplingInterval);
 };
 
-var treeToArrayAcc = function (node, acc) {
+var treeToArrayAcc = function(node, acc) {
     acc.push(node);
     for (var i = 0; i < node.children.length; i++) {
         acc = acc.concat(treeToArrayAcc(node.children[i], []));
@@ -41,7 +41,7 @@ var treeToArrayAcc = function (node, acc) {
     return acc;
 }
 
-var treeToArray = function (node) {
+var treeToArray = function(node) {
     return treeToArrayAcc(node, []);
 }
 
@@ -51,7 +51,7 @@ var fnForCall = function(call) {
             call.functionName, baseUrl, call.lineNumber);
 };
 
-var chromeProfileToCallgrind = function (profile, outStream) {
+var chromeProfileToCallgrind = function(profile, outStream) {
 
     calculateTimes(profile);
 

--- a/index.js
+++ b/index.js
@@ -7,8 +7,10 @@ var _s = require("underscore.string");
 // https://github.com/yoavweiss/Blink/blob/master/Source/devtools/front_end/CPUProfileView.js
 var totalHitCount = function(node) {
     var result = node.hitCount;
-    for (var i = 0; i < node.children.length; i++) {
-        result += totalHitCount(node.children[i]);
+    if (node.children) {
+        for (var i = 0; i < node.children.length; i++) {
+            result += totalHitCount(node.children[i]);
+        }    
     }
     return result;
 };
@@ -17,8 +19,10 @@ var calculateTimesForNode = function(node, samplingInterval) {
     node.selfTime = node.hitCount * samplingInterval;
     node.selfHitCount = node.hitCount;
     var totalHitCount = node.hitCount;
-    for (var i = 0; i < node.children.length; i++) {
-        totalHitCount += calculateTimesForNode(node.children[i], samplingInterval);
+    if (node.children) {
+        for (var i = 0; i < node.children.length; i++) {
+            totalHitCount += calculateTimesForNode(node.children[i], samplingInterval);
+        }    
     }
     node.totalTime = totalHitCount * samplingInterval;
     node.totalHitCount = totalHitCount;
@@ -35,8 +39,10 @@ var calculateTimes = function(profile) {
 
 var treeToArrayAcc = function(node, acc) {
     acc.push(node);
-    for (var i = 0; i < node.children.length; i++) {
-        acc = acc.concat(treeToArrayAcc(node.children[i], []));
+    if (node.children) {
+        for (var i = 0; i < node.children.length; i++) {
+            acc = acc.concat(treeToArrayAcc(node.children[i], []));
+        }
     }
     return acc;
 }
@@ -73,19 +79,21 @@ var chromeProfileToCallgrind = function(profile, outStream) {
         call.selfTime += node.selfTime;
 
         var childCalls = call.childCalls;
-        for(var j = 0; j < node.children.length; j++) {
-            var child = node.children[j];
+        if (node.children) {
+            for(var j = 0; j < node.children.length; j++) {
+                var child = node.children[j];
 
-            var childUID = child.callUID;
-            var childCall = childCalls[childUID] = childCalls[childUID] || {
-                functionName: child.functionName,
-                url: child.url,
-                totalHitCount: 0,
-                totalTime: 0,
-                lineNumber: child.lineNumber
-            };
-            childCall.totalHitCount += child.totalHitCount;
-            childCall.totalTime += child.totalTime;
+                var childUID = child.callUID;
+                var childCall = childCalls[childUID] = childCalls[childUID] || {
+                    functionName: child.functionName,
+                    url: child.url,
+                    totalHitCount: 0,
+                    totalTime: 0,
+                    lineNumber: child.lineNumber
+                };
+                childCall.totalHitCount += child.totalHitCount;
+                childCall.totalTime += child.totalTime;
+            }    
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ var chromeProfileToCallgrind = function(profile, outStream, copy) {
                 };
                 childCall.totalHitCount += child.totalHitCount;
                 childCall.totalTime += child.totalTime;
-            }    
+            }
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -5,14 +5,15 @@ var _s = require("underscore.string");
 
 // Based on WebInspector.CPUProfileView in CPUProfileView.js in Blink source.
 // https://github.com/yoavweiss/Blink/blob/master/Source/devtools/front_end/CPUProfileView.js
-var calculateTimes = function(profile) {
-    var totalHitCount = function(node) {
-        var result = node.hitCount;
-        for (var i = 0; i < node.children.length; i++) {
-            result += totalHitCount(node.children[i]);
-        }
-        return result;
-    };
+var totalHitCount = function(node) {
+    var result = node.hitCount;
+    for (var i = 0; i < node.children.length; i++) {
+        result += totalHitCount(node.children[i]);
+    }
+    return result;
+};
+
+var calculateTimes = function(profile) {    
     profile.totalHitCount = totalHitCount(profile.head);
     profile.totalTime = 1000 * (profile.endTime - profile.startTime);
 


### PR DESCRIPTION
These changes replace callback-style iteration with simple for loop iteration. Addtionally, it removes a call to cloneDeep, as the integrity of the original object need not be maintained.

This updated code was test on both `samples.cpuprofile` and `test.cpuprofile`; there is zero difference in the outputted callgrind data.

Furthermore, I am currently working on some profiling wherein the old version of this script took 20 hours to complete, whereas this version takes under 20 seconds.